### PR TITLE
Edited Apache setup examples to work with 2.4

### DIFF
--- a/manuscript/setup.md
+++ b/manuscript/setup.md
@@ -4,7 +4,7 @@
 
 We are going to point the virtual host to `aura.localhost`.
 If you are in a debain based OS, you want to create a file 
-`/etc/apache2/sites-available/aura2.localhost` with the below contents.
+`/etc/apache2/sites-available/aura2.localhost.conf` with the below contents.
 
 ```bash
 <VirtualHost *:80>
@@ -20,6 +20,8 @@ If you are in a debain based OS, you want to create a file
 
 `path/to/project` is where you installed the `aura/web-project` or 
 `aura/framework-project`.
+
+**NOTE:** Apache 2.4 users might have to add `Require all granted` below `AllowOverride all` in order to prevent a 401 response caused by [the changes in access control](https://httpd.apache.org/docs/2.4/upgrading.html#access).
 
 Enable the site using 
 


### PR DESCRIPTION
## Changes
### Added `.conf` file-extension. Fixes #5.

As seen in issue #5 it seems like the missing file extension causes confusion to the `a2ensite` command in Apache 2.4.
### Added a note about apache 2.4 new access control.

Another issue I ran into. Somehow it wouldn't let me in without this directive. Someone wrote [an article](http://dabase.com/blog/AH01630:_client_denied_by_server_configuration/) describing a similar problem.
